### PR TITLE
Allow for AM/PM in @done tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # CHANGELOG
 
-## v1.4.1, 1.8.2020
+## v1.4.2, 1.8.2020
 - [Change] allow @done(date) to be tided up when time has AM/PM suffix (issue 17)
+
+## v1.4.1, 1.8.2020
 - [New] add new --noarchive option (issue 16)
-- [New] add new --keepscheduled option (issue 15,16)
+- [New] add new --keepscheduled option (issue 14,15)
 
 ## v1.4.0,  26.7.2020
 - [Change] Script now called `npTools`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# CHANGELOG
+
+## v1.4.1, 1.8.2020
+- [Change] allow @done(date) to be tided up when time has AM/PM suffix (issue 17)
+- [New] add new --noarchive option (issue 16)
+- [New] add new --keepscheduled option (issue 15,16)
+
+## v1.4.0,  26.7.2020
+- [Change] Script now called `npTools`
+- [Change] Significant improvements to documentation
+

--- a/npTools.rb
+++ b/npTools.rb
@@ -1,12 +1,12 @@
 #!/usr/bin/ruby
 #-------------------------------------------------------------------------------
 # NotePlan Tools script
-# by Jonathan Clark, v1.4.1, 1.8.2020
+# by Jonathan Clark, v1.4.2, 1.8.2020
 #-------------------------------------------------------------------------------
 # See README.md file for details, how to run and configure it.
 # Repository: https://github.com/jgclark/NotePlan-tools/
 #-------------------------------------------------------------------------------
-VERSION = '1.4.1'.freeze
+VERSION = '1.4.2'.freeze
 
 require 'date'
 require 'time'

--- a/npTools.rb
+++ b/npTools.rb
@@ -522,10 +522,10 @@ class NPFile
       completed_date = ''
       # find lines with date-time to shorten, and capture date part of it
       # i.e. @done(YYYY-MM-DD HH:MM)
-      if line =~ /@done\(\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}\)/
+      if line =~ /@done\(\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}(?:.(?:AM|PM))?\)/
         # get completed date
-        line.scan(/\((\d{4}\-\d{2}\-\d{2}) \d{2}:\d{2}\)/) { |m| completed_date = m.join }
-        updated_line = line.gsub(/\(\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}\)/, "(#{completed_date})")
+        line.scan(/\((\d{4}\-\d{2}\-\d{2}) \d{2}:\d{2}(?:.(?:AM|PM))?\)/) { |m| completed_date = m.join }
+        updated_line = line.gsub(/\(\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}(?:.(?:AM|PM))?\)/, "(#{completed_date})")
         @lines[n] = updated_line
         cleaned += 1
         @is_updated = true

--- a/npTools.rb
+++ b/npTools.rb
@@ -1,12 +1,12 @@
 #!/usr/bin/ruby
 #-------------------------------------------------------------------------------
 # NotePlan Tools script
-# by Jonathan Clark, v1.4.0, 25.7.2020
+# by Jonathan Clark, v1.4.1, 1.8.2020
 #-------------------------------------------------------------------------------
 # See README.md file for details, how to run and configure it.
 # Repository: https://github.com/jgclark/NotePlan-tools/
 #-------------------------------------------------------------------------------
-VERSION = '1.4.0'.freeze
+VERSION = '1.4.1'.freeze
 
 require 'date'
 require 'time'


### PR DESCRIPTION
I'm in the US and so my Time preferences are for a 12-hour clock. NotePlan therefore formats my @done tags as `@done(YYYY-mm-dd HH:MM AM)`. This change should allow for either 12-hour or 24-hour time strings.