### PR TITLE
Adding option flags for new toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# CHANGELOG
+
+## v1.4.1, 1.8.2020
+- [New] add new --noarchive option (issue 16)
+- [New] add new --keepscheduled option (issue 15,16)
+
+## v1.4.0,  26.7.2020
+- [Change] Script now called `npTools`
+- [Change] Significant improvements to documentation
+


### PR DESCRIPTION
This should add new option flags for toggling the following items:

1. Archiving

If the flag `-a` or `--noarchive` is set, then it won't automatically move tasks into the ## Done section.

2. Schedule Removal

If the flag `-s` of `--keepschedules` is set, then it won't remove the scheduled (>) dates of completed tasks.