### PR TITLE
Added --skipfile=NOTETITLE option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ You can also specify options:
 - `-a` (`--noarchive`) don't archive completed tasks into the `# Done` section
 - `-n` (`--nomove`) turn off moving mentions of [[Note]] in a daily calendar day file to the [[Note]]. You'll want to do this if you're using the [[...]] notation for backlinks (from NP v3.0.15 onwards)
 - `-s` (`--keepschedules`) keep the scheduled (>) dates of completed tasks
+- `-f` (`--skipfile=NOTETITLE`) don't process specific note
 - `-i` (`--skiptoday`) don't process today's file
 - `-v` for verbose output 
 - `-w` for more verbose output

--- a/npTools.rb
+++ b/npTools.rb
@@ -773,10 +773,11 @@ opt_parser = OptionParser.new do |opts|
   options[:move] = 1
   options[:archive] = 0 # default off at the moment as feature isn't complete
   options[:remove_scheduled] = 1
+  options[:skipfile] = nil
   options[:skiptoday] = false
   options[:quiet] = false
   options[:verbose] = 0
-  opts.on('-a', '--noarchive', "Don't archive completed tasks into the ## Done section") do
+  opts.on('-a', '--noarchive', "Don't archive completed tasks into the ## Done section") do 
     options[:archive] = 0
   end
   opts.on('-h', '--help', 'Show this help') do
@@ -785,6 +786,9 @@ opt_parser = OptionParser.new do |opts|
   end
   opts.on('-n', '--nomove', "Don't move Daily items with [[Note]] reference to that Note") do
     options[:move] = 0
+  end
+  opts.on('-f', '--skipfile=FILE', "Don't process specific file") do |skipfile| 
+    options[:skipfile] = skipfile
   end
   opts.on('-i', '--skiptoday', "Don't touch today's daily note file") do
     options[:skiptoday] = true
@@ -907,6 +911,10 @@ if $notes.count.positive? # if we have some files to work on ...
   $notes.each do |note|
     if note.is_today && options[:skiptoday]
       puts 'Skipping ' + note.title.to_s.bold + ' due to --skiptoday option'
+      next
+    end
+    if note.title == options[:skipfile]
+      puts 'Skipping ' + note.title.to_s.bold + ' due to --skipfile option'
       next
     end
     puts "Cleaning file id #{note.id} " + note.title.to_s.bold if $verbose > 0


### PR DESCRIPTION
The blank header cleanup was cleaning my Meeting Templates file where I add items to meeting agendas to be pulled into my daily notes.  I'd like to keep the empty headers in that specific case to avoid having to recreate them for recurring meetings.